### PR TITLE
add support for multiple network plugins

### DIFF
--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -22,6 +22,7 @@ type Options struct {
 	hostPrefix          string
 	containerRuntime    controllers.RuntimeKind
 	containerRuntimeStr string
+	networkPlugins      []string
 	// errCh is the channel that errors will be sent
 	errCh chan error
 }
@@ -35,6 +36,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.master, "master", o.master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&o.hostnameOverride, "hostname-override", o.hostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
 	fs.StringVar(&o.hostPrefix, "host-prefix", o.hostnameOverride, "If non-empty, will use this string as prefix for host filesystem.")
+	fs.StringSliceVar(&o.networkPlugins, "network-plugins", []string{"macvlan"}, "List of network plugins to be be considered for network policies.")
 	fs.AddGoFlagSet(flag.CommandLine)
 }
 

--- a/pkg/server/policyrules_test.go
+++ b/pkg/server/policyrules_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/k8snetworkplumbingwg/macvlan-networkpolicy/pkg/controllers"
 	netdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	netfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -46,8 +46,9 @@ func NewFakeServer(hostname string) *Server {
 		return nil
 	}
 	hostPrefix := "/host"
+	networkPlugins := []string{"macvlan"}
 	containerRuntime := controllers.RuntimeKind(controllers.Docker)
-	podChanges := controllers.NewPodChangeTracker(containerRuntime, hostname, hostPrefix, netdefChanges)
+	podChanges := controllers.NewPodChangeTracker(containerRuntime, hostname, hostPrefix, networkPlugins, netdefChanges)
 	if podChanges == nil {
 		return nil
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -212,7 +212,7 @@ func NewServer(o *Options) (*Server, error) {
 	if nsChanges == nil {
 		return nil, fmt.Errorf("cannot create namespace change tracker")
 	}
-	podChanges := controllers.NewPodChangeTracker(o.containerRuntime, hostname, o.hostPrefix, netdefChanges)
+	podChanges := controllers.NewPodChangeTracker(o.containerRuntime, hostname, o.hostPrefix, o.networkPlugins, netdefChanges)
 	if podChanges == nil {
 		return nil, fmt.Errorf("cannot create pod change tracker")
 	}


### PR DESCRIPTION
This PR adds a command line option to enable the support of other network plugins such as ipvlan.